### PR TITLE
Implement 'alsa library is not found' panic.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,25 @@
 extern crate pkg_config;
 
 fn main() {
-    pkg_config::find_library("alsa").unwrap();
+    let missing: String = String::from("\"pkg-config\" \"--libs\" \"--cflags\" \"alsa\"");
+
+    match pkg_config::probe_library("alsa") {
+        Ok(_) => {},
+        Err(e) => {
+            match e {
+                pkg_config::Error::Failure {command, output} => {
+                    if command == missing {
+                        panic! (
+                            "Could not find the alsa library. Have you installed the library on your system?\n\n\
+                            For Fedora users:\n# dnf install alsa-lib-devel\n\n\
+                            For Debian/Ubuntu users:\n# apt-get install libasound2\n\n"
+                        );
+                    } else {
+                        panic!("Command '{}' failed. Details:\n{:?}", command, output);
+                    }
+                },
+                _ => panic!("{}", e)
+            }
+        }
+    };
 }

--- a/build.rs
+++ b/build.rs
@@ -1,25 +1,16 @@
 extern crate pkg_config;
 
 fn main() {
-    let missing: String = String::from("\"pkg-config\" \"--libs\" \"--cflags\" \"alsa\"");
-
-    match pkg_config::probe_library("alsa") {
-        Ok(_) => {},
-        Err(e) => {
-            match e {
-                pkg_config::Error::Failure {command, output} => {
-                    if command == missing {
-                        panic! (
-                            "Could not find the alsa library. Have you installed the library on your system?\n\n\
-                            For Fedora users:\n# dnf install alsa-lib-devel\n\n\
-                            For Debian/Ubuntu users:\n# apt-get install libasound2\n\n"
-                        );
-                    } else {
-                        panic!("Command '{}' failed. Details:\n{:?}", command, output);
-                    }
-                },
-                _ => panic!("{}", e)
-            }
+    if let Err(e) = pkg_config::probe_library("alsa") {
+        match e {
+            pkg_config::Error::Failure { .. } => panic! (
+                "Could not find the alsa library. Have you installed the library on your system?\n\n\
+                For Fedora users:\n# dnf install alsa-lib-devel\n\n\
+                For Debian/Ubuntu users:\n# apt-get install libasound2-dev\n\n\
+                pkg_config details:\n{}",
+                e
+            ),
+            _ => panic!("{}", e)
         }
-    };
+    }
 }


### PR DESCRIPTION
* Replace the deprecated 'find_library' function.
* show a more user-friendly message if the alsa library is not found.