### PR TITLE
Add use-bindgen feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,11 @@ libc = "0.2.65"
 
 [build-dependencies]
 pkg-config = "0.3"
+bindgen = { version = "0.56", optional = true }
 
+[features]
+use-bindgen = ["bindgen"]
+
+[[bin]]
+name = "regenerate_bindings"
+path = "regenerate_bindings.rs"

--- a/README.md
+++ b/README.md
@@ -2,5 +2,13 @@
 
 Rust raw FFI bindings for ALSA.
 
-To avoid too long build times, the finished binding is committed into this repository.
-If you need to regenerate it, run `regenerate_bindings.sh` (and have `bindgen` set up when you do so).
+To avoid too long build times, the finished binding is committed into this
+repository. If you would prefer to generate the bindings at build time, there
+is a `use-bindings` feature to do so.
+
+## Regenerating bindings
+
+To regenerate the bindings yourself, run `regenerate_bindings.sh`. This
+will generate the bindings in the build script, and run the
+`regenerate_bindings` binary, which copies the generated bindings into
+`src/`.

--- a/build.rs
+++ b/build.rs
@@ -48,6 +48,7 @@ fn generate_bindings(alsa_library: &pkg_config::Library) {
         .layout_tests(false)
         .whitelist_function("snd_.*")
         .whitelist_type("_?snd_.*")
+        .whitelist_type(".*va_list.*")
         .with_codegen_config(codegen_config)
         .clang_args(clang_include_args)
         .header("wrapper.h")

--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,62 @@
 extern crate pkg_config;
 
+#[cfg(feature = "use-bindgen")]
+extern crate bindgen;
+
+#[allow(unused_variables)]
 fn main() {
-    if let Err(e) = pkg_config::probe_library("alsa") {
-        match e {
-            pkg_config::Error::Failure { .. } => panic! (
-                "Pkg-config failed - usually this is because alsa development headers are not installed.\n\n\
-                For Fedora users:\n# dnf install alsa-lib-devel\n\n\
-                For Debian/Ubuntu users:\n# apt-get install libasound2-dev\n\n\
-                pkg_config details:\n{}",
-                e
-            ),
-            _ => panic!("{}", e)
-        }
-    }
+    let alsa_library = match pkg_config::Config::new().statik(false).probe("alsa") {
+        Err(e) => {
+            match e {
+                pkg_config::Error::Failure { .. } => panic! (
+                    "Pkg-config failed - usually this is because alsa development headers are not installed.\n\n\
+                    For Fedora users:\n# dnf install alsa-lib-devel\n\n\
+                    For Debian/Ubuntu users:\n# apt-get install libasound2-dev\n\n\
+                    pkg_config details:\n{}",
+                    e
+                ),
+                _ => panic!("{}", e)
+            }
+        },
+        Ok(l) => l
+    };
+
+    #[cfg(feature = "use-bindgen")]
+    generate_bindings(&alsa_library);
+}
+
+#[cfg(feature = "use-bindgen")]
+fn generate_bindings(alsa_library: &pkg_config::Library) {
+    use std::env;
+    use std::path::PathBuf;
+
+    let clang_include_args = alsa_library.include_paths.iter().map(|include_path| {
+        format!(
+            "-I{}",
+            include_path.to_str().expect("include path was not UTF-8")
+        )
+    });
+
+    let mut codegen_config = bindgen::CodegenConfig::empty();
+    codegen_config.insert(bindgen::CodegenConfig::FUNCTIONS);
+    codegen_config.insert(bindgen::CodegenConfig::TYPES);
+
+    let builder = bindgen::Builder::default()
+        .size_t_is_usize(true)
+        .whitelist_recursively(false)
+        .prepend_enum_name(false)
+        .layout_tests(false)
+        .whitelist_function("snd_.*")
+        .whitelist_type("_?snd_.*")
+        .with_codegen_config(codegen_config)
+        .clang_args(clang_include_args)
+        .header("wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks));
+    let bindings = builder.generate().expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    bindings
+        .write_to_file(out_path.join("generated.rs"))
+        .expect("Couldn't write bindings");
 }

--- a/regenerate_bindings.rs
+++ b/regenerate_bindings.rs
@@ -1,0 +1,10 @@
+fn main () {
+    if cfg!(feature = "use-bindgen") {
+        use std::fs::copy;
+        use std::path::PathBuf;
+        let bindings_path = concat!(env!("OUT_DIR"), "/generated.rs");
+        copy(PathBuf::from(bindings_path), PathBuf::from("src/generated.rs")).unwrap();
+    } else {
+        panic!("Must be run with use-bindgen feature");
+    }
+}

--- a/regenerate_bindings.sh
+++ b/regenerate_bindings.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-bindgen --size_t-is-usize --no-recursive-whitelist --no-prepend-enum-name --no-layout-tests \
---generate "functions,types" --whitelist-function="snd_.*" --whitelist-type="_?snd_.*" \
-/usr/include/alsa/asoundlib.h -o src/generated.rs
+
+cargo run --features "use-bindgen" --bin regenerate_bindings

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -111,6 +111,8 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
         fmt.write_str("__IncompleteArrayField")
     }
 }
+pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
 extern "C" {
     #[doc = "  \\defgroup Global Global defines and functions"]
     #[doc = "  Global defines and functions."]
@@ -8743,4 +8745,13 @@ extern "C" {
         count: ::std::os::raw::c_long,
         ev: *const snd_seq_event_t,
     ) -> ::std::os::raw::c_long;
+}
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use libc::{FILE, pid_t, timeval, timespec, pollfd};
+use libc::{pid_t, pollfd, timespec, timeval, FILE};
 
 pub const SND_PCM_NONBLOCK: ::std::os::raw::c_int = 0x1;
 pub const SND_PCM_ASYNC: ::std::os::raw::c_int = 0x2;
@@ -13,20 +13,20 @@ pub const SND_SEQ_ADDRESS_BROADCAST: u8 = 255;
 pub const SND_SEQ_ADDRESS_SUBSCRIBERS: u8 = 254;
 pub const SND_SEQ_ADDRESS_UNKNOWN: u8 = 253;
 pub const SND_SEQ_QUEUE_DIRECT: u8 = 253;
-pub const SND_SEQ_TIME_MODE_MASK: u8 = 1<<1;
-pub const SND_SEQ_TIME_STAMP_MASK: u8 = 1<<0;
-pub const SND_SEQ_TIME_MODE_REL: u8 = 1<<1;
-pub const SND_SEQ_TIME_STAMP_REAL: u8 = 1<<0;
-pub const SND_SEQ_TIME_STAMP_TICK: u8 = 0<<0;
-pub const SND_SEQ_TIME_MODE_ABS: u8 = 0<<1;
+pub const SND_SEQ_TIME_MODE_MASK: u8 = 1 << 1;
+pub const SND_SEQ_TIME_STAMP_MASK: u8 = 1 << 0;
+pub const SND_SEQ_TIME_MODE_REL: u8 = 1 << 1;
+pub const SND_SEQ_TIME_STAMP_REAL: u8 = 1 << 0;
+pub const SND_SEQ_TIME_STAMP_TICK: u8 = 0 << 0;
+pub const SND_SEQ_TIME_MODE_ABS: u8 = 0 << 1;
 pub const SND_SEQ_CLIENT_SYSTEM: u8 = 0;
 pub const SND_SEQ_PORT_SYSTEM_TIMER: u8 = 0;
 pub const SND_SEQ_PORT_SYSTEM_ANNOUNCE: u8 = 1;
-pub const SND_SEQ_PRIORITY_HIGH: u8 = 1<<4;
-pub const SND_SEQ_EVENT_LENGTH_FIXED: u8 = 0<<2;
-pub const SND_SEQ_EVENT_LENGTH_MASK: u8 = 3<<2;
-pub const SND_SEQ_EVENT_LENGTH_VARIABLE: u8 = 1<<2;
-pub const SND_SEQ_EVENT_LENGTH_VARUSR: u8 = 2<<2;
+pub const SND_SEQ_PRIORITY_HIGH: u8 = 1 << 4;
+pub const SND_SEQ_EVENT_LENGTH_FIXED: u8 = 0 << 2;
+pub const SND_SEQ_EVENT_LENGTH_MASK: u8 = 3 << 2;
+pub const SND_SEQ_EVENT_LENGTH_VARIABLE: u8 = 1 << 2;
+pub const SND_SEQ_EVENT_LENGTH_VARUSR: u8 = 2 << 2;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -37,4 +37,8 @@ pub struct __va_list_tag {
     pub reg_save_area: *mut ::std::os::raw::c_void,
 }
 
+#[cfg(feature = "use-bindgen")]
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+#[cfg(not(feature = "use-bindgen"))]
 include!("generated.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,15 +28,6 @@ pub const SND_SEQ_EVENT_LENGTH_MASK: u8 = 3 << 2;
 pub const SND_SEQ_EVENT_LENGTH_VARIABLE: u8 = 1 << 2;
 pub const SND_SEQ_EVENT_LENGTH_VARUSR: u8 = 2 << 2;
 
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __va_list_tag {
-    pub gp_offset: ::std::os::raw::c_uint,
-    pub fp_offset: ::std::os::raw::c_uint,
-    pub overflow_arg_area: *mut ::std::os::raw::c_void,
-    pub reg_save_area: *mut ::std::os::raw::c_void,
-}
-
 #[cfg(feature = "use-bindgen")]
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,0 +1,1 @@
+#include<asoundlib.h>

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,1 +1,1 @@
-#include<asoundlib.h>
+#include <asoundlib.h>


### PR DESCRIPTION
Addresses https://github.com/diwic/alsa-sys/issues/2

Points of discussion:
- I have deleted the old `regenerate_bindings.sh` script, because maintaining the bindgen arguments in two places seemed like it would be prone to failure. To regenerate the bindings now, you just run `cargo build --features "use-bindgen"` and the bindings are generated by the build script.
- The bindgen API does not seem to have an option for the `--generate "functions,types"` argument that is present on the CLI. I have assumed this is the default, so left it out.
- On my system, the generated bindings in `generated.rs` are different from what is committed. I'm not sure whether this is because I have different header files to whoever ran the `regenerate-bindings.sh` script last, or because I have specified the bindgen options wrong, or something else.