### PR TITLE
Update README.md: Add build dependency installation guide for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ To avoid too long build times, the finished binding is committed into this
 repository. If you would prefer to generate the bindings at build time, there
 is a `use-bindings` feature to do so.
 
+## Installing build dependencies
+
+### Debian/Ubuntu/Mint
+
+```
+sudo apt install libasound2-dev
+```
+
 ## Regenerating bindings
 
 To regenerate the bindings yourself, run `regenerate_bindings.sh`. This


### PR DESCRIPTION
Hello. It took me a few minutes to find out I have to install `libasound2-dev`. And to reach this goal, I had to find that the software I am trying to build uses `alsa-sys`, find the repo, look into the `.h` file, see that it requires a header file, and finally with `apt-file` find this header file belongs to which package.

Hopefully, this PR will save time for the next person, especially if they haven't got prior experience with compiling stuff.