### PR TITLE
fix: measure sizeof(struct timespec) instead of reading __TIMESIZE

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -41,33 +41,49 @@ fn probe_time64() {
         return;
     }
 
-    let probe_path = std::path::Path::new(&std::env::var("OUT_DIR").unwrap()).join("time64_probe.c");
-    if let Err(e) = std::fs::write(
-        &probe_path,
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+
+    // Checks the type, not just that a compiler exists: an unusable <time.h>
+    // would fail the probe below and be read as pre-transition, which is the
+    // direction that segfaults.
+    if !compiles(
+        &out_dir,
+        "time64_control.c",
         "#include <time.h>\n\
-         #if defined(__TIMESIZE) && __TIMESIZE == 64\n\
-         alsa_sys_time64=yes\n\
-         #else\n\
-         alsa_sys_time64=no\n\
-         #endif\n",
+         _Static_assert(sizeof(struct timespec) == 8\n\
+                     || sizeof(struct timespec) == 16, \"unexpected timespec\");\n",
     ) {
-        println!("cargo:warning=alsa-sys: could not write time64 probe ({e}), assuming legacy 32-bit time_t");
+        println!("cargo:warning=alsa-sys: could not probe glibc's time_t width, assuming legacy 32-bit time_t");
         return;
     }
 
-    // On failure, default to 32-bit time_t. A false negative is a no-op, a
-    // false positive causes segfaults.
-    let expanded = match cc::Build::new().file(&probe_path).try_expand() {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            println!("cargo:warning=alsa-sys: could not probe glibc time_t width ({e}), assuming legacy 32-bit time_t");
-            return;
-        }
-    };
-
-    if String::from_utf8_lossy(&expanded).contains("alsa_sys_time64=yes") {
+    // 16 bytes exactly when the 64-bit time_t ABI is in effect, from the port
+    // default or from _TIME_BITS=64 in the toolchain, as on Debian trixie.
+    // __TIMESIZE sees neither: it stays 32 on every architecture that went
+    // through the transition. Compiles but never runs, so cross builds work.
+    if compiles(
+        &out_dir,
+        "time64_probe.c",
+        "#include <time.h>\n\
+         _Static_assert(sizeof(struct timespec) == 16, \"64-bit time_t\");\n",
+    ) {
         println!("cargo:rustc-cfg=alsa_sys_time64");
     }
+}
+
+/// Compiles a snippet against the target's headers. Nothing is linked or run.
+fn compiles(out_dir: &std::path::Path, name: &str, source: &str) -> bool {
+    let path = out_dir.join(name);
+    if std::fs::write(&path, source).is_err() {
+        return false;
+    }
+    cc::Build::new()
+        .file(&path)
+        .cargo_metadata(false)
+        .cargo_warnings(false)
+        .warnings(false)
+        .try_compile(name.trim_end_matches(".c"))
+        .is_ok()
 }
 
 #[cfg(feature = "use-bindgen")]

--- a/build.rs
+++ b/build.rs
@@ -4,8 +4,6 @@ extern crate pkg_config;
 extern crate bindgen;
 
 fn main() {
-    probe_time64();
-
     match pkg_config::Config::new().statik(false).probe("alsa") {
         Err(pkg_config::Error::Failure { command, output }) => panic!(
             "Pkg-config failed - usually this is because alsa development headers are not installed.\n\n\
@@ -14,17 +12,18 @@ fn main() {
             For Archlinux users:\n# pacman -S alsa-lib\n\n
             pkg_config details:\n{}\n", pkg_config::Error::Failure { command, output }),
         Err(e) => panic!("{}", e),
-        Ok(_alsa_library) => {
+        Ok(alsa_library) => {
+            probe_time64(&alsa_library);
             #[cfg(feature = "use-bindgen")]
-            generate_bindings(&_alsa_library);
+            generate_bindings(&alsa_library);
         }
     };
 }
 
-// 32-bit glibc's struct timespec is 8 or 16 bytes depending on the time64
-// transition; libc::timespec assumes 8, so ALSA can write past it and
-// segfault on 32-bit targets with time64.
-fn probe_time64() {
+// 32-bit glibc's snd_htimestamp_t (a struct timespec) is 8 or 16 bytes
+// depending on the time64 transition; libc::timespec assumes 8, so ALSA can
+// write past it and segfault on 32-bit targets with a 64-bit time_t.
+fn probe_time64(alsa_library: &pkg_config::Library) {
     println!("cargo:rustc-check-cfg=cfg(alsa_sys_time64)");
 
     let target_os = std::env::var("CARGO_CFG_TARGET_OS");
@@ -42,48 +41,66 @@ fn probe_time64() {
     }
 
     let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let include_paths = &alsa_library.include_paths;
 
-    // Checks the type, not just that a compiler exists: an unusable <time.h>
-    // would fail the probe below and be read as pre-transition, which is the
-    // direction that segfaults.
-    if !compiles(
+    // Measures the exact type libasound writes through. If even this control
+    // snippet does not compile, there is no safe width to assume: guessing 8
+    // can segfault and guessing 16 yields garbage timestamps, so stop the
+    // build with a diagnosable error instead.
+    if let Err(e) = try_compile(
         &out_dir,
+        include_paths,
         "time64_control.c",
-        "#include <time.h>\n\
-         _Static_assert(sizeof(struct timespec) == 8\n\
-                     || sizeof(struct timespec) == 16, \"unexpected timespec\");\n",
+        "#include <alsa/asoundlib.h>\n\
+         _Static_assert(sizeof(snd_htimestamp_t) == 8\n\
+                     || sizeof(snd_htimestamp_t) == 16, \"unexpected snd_htimestamp_t\");\n",
     ) {
-        println!("cargo:warning=alsa-sys: could not probe glibc's time_t width, assuming legacy 32-bit time_t");
-        return;
+        panic!(
+            "alsa-sys could not compile a probe measuring sizeof(snd_htimestamp_t) \
+             against the ALSA headers. On 32-bit glibc targets that size decides \
+             whether libasound writes 8 or 16 bytes per timestamp, and guessing \
+             wrong corrupts memory, so the build stops instead.\n\
+             Check that the C compiler and the ALSA headers for the target work.\n\n\
+             {}",
+            e
+        );
     }
 
     // 16 bytes exactly when the 64-bit time_t ABI is in effect, from the port
     // default or from _TIME_BITS=64 in the toolchain, as on Debian trixie.
     // __TIMESIZE sees neither: it stays 32 on every architecture that went
     // through the transition. Compiles but never runs, so cross builds work.
-    if compiles(
+    if try_compile(
         &out_dir,
+        include_paths,
         "time64_probe.c",
-        "#include <time.h>\n\
-         _Static_assert(sizeof(struct timespec) == 16, \"64-bit time_t\");\n",
-    ) {
+        "#include <alsa/asoundlib.h>\n\
+         _Static_assert(sizeof(snd_htimestamp_t) == 16, \"64-bit time_t\");\n",
+    )
+    .is_ok()
+    {
         println!("cargo:rustc-cfg=alsa_sys_time64");
     }
 }
 
-/// Compiles a snippet against the target's headers. Nothing is linked or run.
-fn compiles(out_dir: &std::path::Path, name: &str, source: &str) -> bool {
+/// Compiles a snippet against the target's ALSA headers. Nothing is linked
+/// or run.
+fn try_compile(
+    out_dir: &std::path::Path,
+    include_paths: &[std::path::PathBuf],
+    name: &str,
+    source: &str,
+) -> Result<(), String> {
     let path = out_dir.join(name);
-    if std::fs::write(&path, source).is_err() {
-        return false;
-    }
+    std::fs::write(&path, source).map_err(|e| e.to_string())?;
     cc::Build::new()
         .file(&path)
+        .includes(include_paths)
         .cargo_metadata(false)
         .cargo_warnings(false)
         .warnings(false)
         .try_compile(name.trim_end_matches(".c"))
-        .is_ok()
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(feature = "use-bindgen")]


### PR DESCRIPTION
## Context

While cross-compiling an audio application for 32-bit Raspberry Pi OS (armhf), I hit the segfault described in diwic/alsa-rs#158 and RustAudio/cpal#1285: libasound writes a 16-byte `struct timespec` while `alsa-sys` re-exports the 8-byte `libc::timespec`.

To be upfront: I'm a developer, but not a Rust developer, and I used Claude to track this down and to write the patch. The measurements and verification below were run for real in the two Raspberry Pi OS images, and I'm happy to rework anything.

## Problem

The probe added in #19 reads `__TIMESIZE`, but that macro reports the port's *default* `time_t` width. Debian's time64 transition works differently: it switches existing 32-bit targets to a 64-bit `time_t` by passing `_TIME_BITS=64` in the toolchain, which leaves `__TIMESIZE` at 32. So on transitioned targets such as armhf and i386 the cfg is not emitted, which is exactly where it is needed — forcing it by hand is what made @d3d9's test pass in #158.

Measured in the two Raspberry Pi OS armhf images, by poisoning a 16-byte buffer and passing it to `snd_pcm_status_get_htstamp` on the `null` PCM:

| | bookworm | trixie |
|---|---|---|
| libasound package | `libasound2` 1.2.8-1+rpt1 | `libasound2t64` 1.2.14-1+rpt1 |
| bytes written | 8 | 16 |
| `sizeof(struct timespec)` | 8 | 16 |
| `__TIMESIZE` | 32 | 32 |
| `__USE_TIME_BITS64` | undefined | defined |

## Change

Measure `sizeof(struct timespec)` directly by compiling a `_Static_assert`, instead of inferring the width from a macro. The snippet is compiled but never run, so cross-compiling against the target's sysroot keeps working. A control compile first checks that `<time.h>` yields a usable timespec, so a broken toolchain produces a warning and the safe 32-bit fallback instead of being misread as a pre-transition target (the direction that corrupts memory).

Checking `__USE_TIME_BITS64` would also work on both images and is a smaller change if you prefer it; I went with the size because it holds regardless of which mechanism set the width.

## Verification

Same container, same libasound, trixie armhf:

```
with this change       cargo:rustc-cfg=alsa_sys_time64
build.rs from master   no rustc-cfg emitted
```

On bookworm armhf the cfg is still (correctly) not emitted, since both `libc::timespec` and the library's timespec are 8 bytes there. 64-bit glibc and musl targets return early at the existing guard, as before.

One gap: I could not test riscv32, a port born with a 64-bit `time_t` where `__TIMESIZE` is already 64. The assertion should compile there and keep the cfg on, but that path is reasoned, not measured.